### PR TITLE
support fetch v8 and glient sync

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -2,8 +2,18 @@ export ZOPEN_BUILD_LINE="DEV"
 export ZOPEN_DEV_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 export ZOPEN_DEV_DEPS="python"
 export ZOPEN_RUNTIME_DEPS="python"
-export ZOPEN_BOOTSTRAP='python3'
-export ZOPEN_BOOTSTRAP_OPTS='bootstrap/bootstrap.py'
+export ZOPEN_BOOTSTRAP="python3"
+export ZOPEN_PYTHONDIR=`type python3 | head -1 | sed "s:^.*[ (]/:/:;s:)$::"`
+export ZOPEN_BOOTSTRAP_OPTS="bootstrap/bootstrap.py --bootstrap-name ${ZOPEN_PYTHONDIR}"
+# Nothing to configure or build:
+export ZOPEN_CONFIGURE="skip"
+export ZOPEN_MAKE="skip"
+export ZOPEN_INSTALL="zopen_install"
+
+zopen_install() {
+  mkdir -p $ZOPEN_INSTALL_DIR
+  cp -r * $ZOPEN_INSTALL_DIR/ # modify to copy the relevant scripts
+}
 
 zopen_check_results()
 {

--- a/patches/cipd.patch
+++ b/patches/cipd.patch
@@ -1,0 +1,32 @@
+diff --git a/cipd b/cipd
+index f7f4133a..2cfcde3a 100755
+--- a/cipd
++++ b/cipd
+@@ -39,6 +39,10 @@ case "${UNAME}" in
+       ARCH="${ARCH_MAC_OVERRIDE}"
+     fi
+     ;;
++  os/390)
++    OS=zos
++    ARCH=s390x
++    ;;
+   *)
+     >&2 echo "CIPD not supported on ${UNAME}"
+     exit 1
+@@ -76,8 +80,14 @@ if [ -z $ARCH ]; then
+       ARCH=riscv64
+       ;;
+     *)
+-      >&2 echo "UNKNOWN Machine architecture: ${UNAME}"
+-      exit 1
++      # uname -m changes with machine type (e.g. 3931 for z16, 8561 for z15)
++      UNAME=`uname -s | tr '[:upper:]' '[:lower:]'`
++      if [[ "$UNAME" == "os/390" ]]; then
++        ARCH=s390x
++      else
++        >&2 echo "UNKNOWN Machine architecture: ${UNAME}"
++        exit 1
++      fi
+   esac
+ fi
+ 

--- a/patches/detect_host_arch.py.patch
+++ b/patches/detect_host_arch.py.patch
@@ -1,0 +1,13 @@
+diff --git a/detect_host_arch.py b/detect_host_arch.py
+index 7669d9ec..67d1e0cb 100755
+--- a/detect_host_arch.py
++++ b/detect_host_arch.py
+@@ -28,6 +28,8 @@ def HostArch():
+         host_arch = 'mips'
+     elif host_arch.startswith('ppc') or host_processor == 'powerpc':
+         host_arch = 'ppc'
++    elif platform.system() == 'OS/390':
++        host_arch = 's390x'
+     elif host_arch.startswith('s390'):
+         host_arch = 's390'
+     elif host_arch.startswith('riscv'):

--- a/patches/download_from_google_storage.py.patch
+++ b/patches/download_from_google_storage.py.patch
@@ -1,0 +1,12 @@
+diff --git a/download_from_google_storage.py b/download_from_google_storage.py
+index 0af4fd7f..73cb87df 100755
+--- a/download_from_google_storage.py
++++ b/download_from_google_storage.py
+@@ -35,6 +35,7 @@ PLATFORM_MAPPING = {
+     'win32': 'win',
+     'aix6': 'aix',
+     'aix7': 'aix',
++    'zos': 'zos',
+ }
+ 
+ 

--- a/patches/gclient.py.patch
+++ b/patches/gclient.py.patch
@@ -1,0 +1,28 @@
+diff --git a/gclient.py b/gclient.py
+index 9d490f8a..2b054a70 100755
+--- a/gclient.py
++++ b/gclient.py
+@@ -1503,6 +1503,7 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+             'checkout_mips': 'mips' in self.target_cpu,
+             'checkout_mips64': 'mips64' in self.target_cpu,
+             'checkout_ppc': 'ppc' in self.target_cpu,
++            'checkout_zos': 'zos' in self.target_cpu,
+             'checkout_s390': 's390' in self.target_cpu,
+             'checkout_x64': 'x64' in self.target_cpu,
+             'host_cpu': detect_host_arch.HostArch(),
+@@ -1534,6 +1535,7 @@ _PLATFORM_MAPPING = {
+     'linux': 'linux',
+     'win32': 'win',
+     'aix6': 'aix',
++    'zos': 'zos',
+ }
+ 
+ 
+@@ -1608,6 +1610,7 @@ class GClient(GitDependency):
+         "ios": "ios",
+         "fuchsia": "fuchsia",
+         "chromeos": "chromeos",
++        "zos": "zos",
+     }
+ 
+     DEFAULT_CLIENT_FILE_TEXT = ("""\

--- a/patches/gclient_paths.py.patch
+++ b/patches/gclient_paths.py.patch
@@ -1,0 +1,13 @@
+diff --git a/gclient_paths.py b/gclient_paths.py
+index 3e4522a5..5c8ae29b 100644
+--- a/gclient_paths.py
++++ b/gclient_paths.py
+@@ -139,6 +139,8 @@ def GetBuildtoolsPlatformBinaryPath():
+         subdir = 'mac'
+     elif sys.platform.startswith('linux'):
+         subdir = 'linux64'
++    elif sys.platform == 'zos':
++        subdir = 'zos'
+     else:
+         raise gclient_utils.Error('Unknown platform: ' + sys.platform)
+     return os.path.join(buildtools_path, subdir)

--- a/patches/gclient_utils.py.patch
+++ b/patches/gclient_utils.py.patch
@@ -1,0 +1,23 @@
+diff --git a/gclient_utils.py b/gclient_utils.py
+index e017f996..d0b3e904 100644
+--- a/gclient_utils.py
++++ b/gclient_utils.py
+@@ -630,7 +630,7 @@ def CheckCallAndFilter(args,
+         # subprocess when filtering its output. This makes the subproc believe
+         # it was launched from a terminal, which will preserve ANSI color codes.
+         os_type = GetOperatingSystem()
+-        if sys.stdout.isatty() and os_type != 'win' and os_type != 'aix':
++        if sys.stdout.isatty() and os_type not in ['win', 'aix', 'zos']:
+             pipe_reader, pipe_writer = os.openpty()
+         else:
+             pipe_reader, pipe_writer = os.pipe()
+@@ -791,6 +791,9 @@ def GetOperatingSystem():
+     if sys.platform.startswith('aix'):
+         return 'aix'
+ 
++    if sys.platform == 'zos':
++        return 'zos'
++
+     try:
+         return os.uname().sysname.lower()
+     except AttributeError:

--- a/patches/vpython3.patch
+++ b/patches/vpython3.patch
@@ -1,0 +1,14 @@
+diff --git a/vpython3 b/vpython3
+index 1ff7a252..cf93ddd4 100755
+--- a/vpython3
++++ b/vpython3
+@@ -48,6 +48,9 @@ case "${DEPOT_TOOLS_UNAME_S}" in
+ mingw*|cygwin*)
+   cmd.exe //c $0.bat "$@"
+   ;;
++os/390)
++  exec python3 "$@"
++  ;;
+ *)
+   exec "${base_dir}/.cipd_bin/vpython3" "$@"
+   ;;


### PR DESCRIPTION
Both subject commands now run on z/OS, but fail at a later stage as they run the CIPD client bootstrap, which is not yet ported.